### PR TITLE
Remove predictor deploy from run test job yaml

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Python 3
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9.12
+          python-version: 3.9.13
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ deploy.predictor:
 	kubectl apply -f ./perf_test/k8s/pytorch-predictor.yaml
 	kubectl apply -f ./perf_test/k8s/tensorflow-predictor.yaml
 	kubectl apply -f ./perf_test/k8s/xgboost-predictor.yaml
+	kubectl apply -f ./perf_test/k8s/example-mnist-predictor.yaml
+
+# Delete the resources used with the performance tests
+delete.predictor:
+	kubectl delete -f ./perf_test/k8s/example-mnist-predictor.yaml --ignore-not-found=true
 
 # Run perf-test from the local machine
 run.howitzer-local:
@@ -49,5 +54,5 @@ run.perf-test: run.delete-perf-test-job deploy.predictor
 	kubectl apply -f ./perf_test/k8s/howitzer_k6_test-k8s.yaml
 # kubectl wait po -l='job-name=perf-test-job' --for=condition=READY=true --timeout=300s
 # kubectl logs -f `kubectl get po -l='job-name=perf-test-job' -o jsonpath='{.items[*].metadata.name}'`
-run.delete-perf-test-job:
-	kubectl delete -f ./perf_test/k8s/howitzer_k6_test-k8s.yaml
+run.delete-perf-test-job: delete.predictor
+	kubectl delete -f ./perf_test/k8s/howitzer_k6_test-k8s.yaml --ignore-not-found=true

--- a/perf_test/k8s/howitzer_k6_test-k8s.yaml
+++ b/perf_test/k8s/howitzer_k6_test-k8s.yaml
@@ -1,15 +1,3 @@
-apiVersion: serving.kserve.io/v1alpha1
-kind: Predictor
-metadata:
-  name: example-mnist-predictor
-spec:
-  modelType:
-    name: sklearn
-  path: sklearn/mnist-svm.joblib
-  storage:
-    s3:
-      secretKey: localMinIO
----
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Remove predictor deploy from run test job yaml because it would
fail sometimes duo to the predictor not ready in time to serve
the job. There is a separate yaml to deploy the predictor, and
it is used in make run.perf-test. So it is safe to have two
commands to 1. deploy the predictor 2. run performance test,
instead of packing into one yaml.

Also add --ignore-not-found=true otherwise the make command will
stop with an erro when there is no existing resources.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>