### PR TITLE
Add a GRPCClient that is re-usable by the same VU

### DIFF
--- a/k6_test/grpc/grpc_client.js
+++ b/k6_test/grpc/grpc_client.js
@@ -20,9 +20,9 @@ function checkResponse(res) {
 
 export class GrpcClient {
   constructor(options) {
-    this.grpcHost = options.grpcHost;
-    this.client = getClient(options.protoFilePath);
-    this.inferRPCName = options.inferRPCName;
+    this.grpcHost = options.grpcHost || 'modelmesh-serving:8033';
+    this.client = getClient(options.protoFilePath || '../k6_test/kfs_inference_v2.proto');
+    this.inferRPCName = options.inferRPCName || 'inference.GRPCInferenceService/ModelInfer';
 
     // Client can't connect on the init context
     this.connected = false;

--- a/k6_test/grpc/grpc_client.js
+++ b/k6_test/grpc/grpc_client.js
@@ -1,0 +1,45 @@
+import { check } from "k6";
+import { Counter } from "k6/metrics";
+import grpc from "k6/net/grpc";
+
+const grpcReqs = new Counter("grpc_reqs");
+
+function getClient(protoFilePath) {
+  const client = new grpc.Client();
+
+  client.load([], protoFilePath);
+
+  return client;
+}
+
+function checkResponse(res) {
+  check(res, {
+    "status is OK": (r) => r && r.status === grpc.StatusOK,
+  });
+}
+
+export class GrpcClient {
+  constructor(options) {
+    this.grpcHost = options.grpcHost;
+    this.client = getClient(options.protoFilePath);
+    this.inferRPCName = options.inferRPCName;
+
+    // Client can't connect on the init context
+    this.connected = false;
+  }
+
+  infer(data, params) {
+    if (!this.connected) {
+      this.client.connect(this.grpcHost, { plaintext: true });
+      this.connected = true;
+    }
+
+    const res = this.client.invoke(this.inferRPCName, data, params);
+    checkResponse(res);
+    grpcReqs.add(1);
+  }
+
+  close() {
+    this.client.close();
+  }
+}

--- a/k6_test/grpc/script_grpc_skmnist.js
+++ b/k6_test/grpc/script_grpc_skmnist.js
@@ -3,9 +3,7 @@ import { GrpcClient } from "../k6_test/grpc/grpc_client.js";
 {{k6_opts}}
 
 const sharedClient = new GrpcClient({
-  grpcHost: '{{base_url}}',
-  protoFilePath: '../k6_test/kfs_inference_v2.proto',
-  inferRPCName: 'inference.GRPCInferenceService/ModelInfer'
+  grpcHost: '{{base_url}}'
 });
 const inputsData = JSON.parse(open(`../k6_test/payloads/{{payload}}`));
 let params = {


### PR DESCRIPTION
Inspo from MLServer benchmark [GRPC Client](https://github.com/SeldonIO/MLServer/blob/74db1766293eca07b54d75d22b34cb635071d3aa/benchmarking/common/grpc.js).

This is to make sure each VU or thread can re-use the same GRPC connection for the entirety of testing. Not re connect every test.

With this change, when each test is run, each VU should open 1 connection. So if the test has 5 vus, if you run a port-forward, you should see 5 "Handling connection..." logs and only 5.


Signed-off-by: Angel Luu <angel.luu@us.ibm.com>